### PR TITLE
Fix AttributeError

### DIFF
--- a/autotag
+++ b/autotag
@@ -23,11 +23,11 @@ def main(file, threshold, limit, bs, group_tags, model):
 
         for filepath, tags in zip(filepaths, predictions):
             if group_tags:
-                data = { "filename": filepath.name, "tags": tags }
+                data = { "filename": filepath, "tags": tags }
                 click.echo(json.dumps(data))
             else:
                 for tag, score in tags.items():
-                    data = { "filename": filepath.name, "tag": tag, "score": score }
+                    data = { "filename": filepath, "tag": tag, "score": score }
                     click.echo(json.dumps(data))
 
 def get_filepaths(paths):


### PR DESCRIPTION
Running ``autotag`` failed with the following error. This pull request fixes this error.
```
Traceback (most recent call last):
  File "…/autotagger/./autotag", line 41, in <module>
    main()
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "…/autotagger/./autotag", line 26, in main
    data = { "filename": filepath.name, "tags": tags }
AttributeError: 'str' object has no attribute 'name'
```